### PR TITLE
Bug fix (fix_indentation_after_colon)

### DIFF
--- a/sigmund/process_sigmund_message.py
+++ b/sigmund/process_sigmund_message.py
@@ -79,7 +79,7 @@ def fix_indentation_after_colon(text: str) -> str:
         #indent = len(line) - len(stripped)
 
         # Detect start of a paragraph that ends with ":" but not already a list item
-        if stripped.endswith(':') and not stripped.startswith('-') and not re.match(r'^\d+\.', stripped):
+        if stripped.endswith(':') and not stripped.startswith('-') and not re.match(r'^\d+\.', stripped) and not lines[-1] == line:
             inside_intro_block = True
             fixed_lines.append(line)
             indent = len(lines[i+1]) - len(lines[i+1].lstrip())

--- a/tests/cheap/test_process_sigmund_message.py
+++ b/tests/cheap/test_process_sigmund_message.py
@@ -439,6 +439,13 @@ def test_fix_list_formatting_12():
     assert output == expected
 
 def test_fix_indentation_after_colon():
+    
+    #Should not crash when last row in the text ends with a colon
+    input_text = """This will be the last row of the text:"""
+    expected = """This will be the last row of the text:"""
+    output = fix_indentation_after_colon(input_text)
+    assert output == expected
+    
     #Should dedent lists, so it is formatted correctly after
     input_text = """This will be a list:
         - point 1


### PR DESCRIPTION
Previously, the function crashed when the last line of text ended with a colon. Simply ending the check in the second to last line solves this bug.